### PR TITLE
platformio.ini: Hardcode download speed to 460800 bauds

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,3 +14,4 @@ board = m5stack-atom
 framework = arduino
 monitor_speed = 115200
 build_flags = -DCORE_DEBUG_LEVEL=3
+upload_speed = 460800


### PR DESCRIPTION
Else I'm getting

$ platformio run -t upload
Processing m5stack-atom (platform: espressif32; board: m5stack-atom; framework: arduino) ----------------------------------------------------------------------------------------------------------------------- Verbose mode can be enabled via `-v, --verbose` option CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/m5stack-atom.html PLATFORM: Espressif 32 (6.0.0) > M5Stack-ATOM
HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
DEBUG: Current (cmsis-dap) External (cmsis-dap, esp-bridge, esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa) PACKAGES:
 - framework-arduinoespressif32 @ 3.20006.221224 (2.0.6)
 - tool-esptoolpy @ 1.40400.0 (4.4.0)
 - tool-mkfatfs @ 2.0.1
 - tool-mklittlefs @ 1.203.210628 (2.3)
 - tool-mkspiffs @ 2.230.0 (2.30)
 - toolchain-xtensa-esp32 @ 8.4.0+2021r2-patch5 LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 33 compatible libraries
Scanning dependencies...
Dependency Graph
|-- ESP32 BLE Arduino @ 2.0.0
Building in release mode
Retrieving maximum program size .pio/build/m5stack-atom/firmware.elf Checking size .pio/build/m5stack-atom/firmware.elf Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [=         ]  13.5% (used 44232 bytes from 327680 bytes)
Flash: [==========]  97.9% (used 1282841 bytes from 1310720 bytes)
Configuring upload protocol...
AVAILABLE: cmsis-dap, esp-bridge, esp-prog, espota, esptool, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa
CURRENT: upload_protocol = esptool
Looking for upload port...
Auto-detected: /dev/ttyUSB0
Uploading .pio/build/m5stack-atom/firmware.bin
esptool.py v4.4
Serial port /dev/ttyUSB0
Connecting............
Chip is ESP32-D0WDQ6 (revision v1.0)
Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 94:b9:7e:d9:af:a4
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 1500000
Changed.
Configuring flash size...
Traceback (most recent call last):
  File "/home/dirk/.platformio/packages/tool-esptoolpy/esptool.py", line 34, in <module>
    esptool._main()
  File "/home/dirk/.platformio/packages/tool-esptoolpy/esptool/__init__.py", line 1026, in _main
    main()
  File "/home/dirk/.platformio/packages/tool-esptoolpy/esptool/__init__.py", line 810, in main
    esp.flash_set_parameters(flash_size_bytes(args.flash_size))
  File "/home/dirk/.platformio/packages/tool-esptoolpy/esptool/loader.py", line 1145, in flash_set_parameters
    self.check_command(
  File "/home/dirk/.platformio/packages/tool-esptoolpy/esptool/loader.py", line 407, in check_command
    val, data = self.command(op, data, chk, timeout=timeout)
  File "/home/dirk/.platformio/packages/tool-esptoolpy/esptool/loader.py", line 376, in command
    p = self.read()
  File "/home/dirk/.platformio/packages/tool-esptoolpy/esptool/loader.py", line 308, in read
    return next(self._slip_reader)
StopIteration
*** [upload] Error 1
============================================= [FAILED] Took 8.22 seconds =============================================