### PR TITLE
main: ButtonCallbackTank: Correct the max value to 200

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,10 +47,10 @@ void ButtonCallbackTank (int button, int state)
             vel[idx] = 0;
             break;
         case(LEGORemote::UP):
-            vel[idx] = 255;
+            vel[idx] = 200;
             break;
         case(LEGORemote::DOWN):
-            vel[idx] = -255;
+            vel[idx] = -200;
             break;
         case(LEGORemote::STOP):
             vel[idx] = 0;


### PR DESCRIPTION
The CircuitCube::BuildVelocityCommand() adds 55 to the value sent to the CircuitCube. As the max value is 255, passing 255 to it results in an overflow, resulting in no Cube (Tank) movement. Limit the value to 200 so that in the end 255, the max value, is sent. In main loop() see the for() loop in TRAIN_CONTROL mode which limits the max value to 200, too.

This is for non TRAIN_CONTROL mode (i.e. TRAIN_CONTROL define disabled).