### PR TITLE
LEGORemote: Wait for remote bluetooth being enabled

### DIFF
--- a/src/LEGORemote.cpp
+++ b/src/LEGORemote.cpp
@@ -9,10 +9,11 @@ const std::string LEGO_REMOTE_CHARACTERISTICS_UUID = "00001624-1212-efde-1623-78
 LEGORemote::LEGORemote ()
 {}
 
-void LEGORemote::Init ()
+bool LEGORemote::Init ()
 {
     BLEScan *pScan = BLEDevice::getScan();
     BLEScanResults results = pScan->start(2);
+    bool found = false;
     
     BLEUUID LEGOServiceUuid (LEGO_REMOTE_SERVICE_UUID);
     
@@ -37,12 +38,13 @@ void LEGORemote::Init ()
                         WriteValue (activatePortDeviceMessage, 8);
                         activatePortDeviceMessage[1] = LEGORemote::RIGHT;
                         WriteValue (activatePortDeviceMessage, 8);
+                        found = true;
                     }
                 }
             }
         }
     }
-
+    return found;
 }
 
 void LEGORemote::SetButtonCallback (std::function<void(int, int)> callback)

--- a/src/LEGORemote.h
+++ b/src/LEGORemote.h
@@ -9,7 +9,7 @@ public:
     LEGORemote ();
     virtual ~LEGORemote () {}
 
-    void Init ();
+    bool Init ();
     void SetButtonCallback (std::function<void(int, int)> callback);
 
     enum

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,9 +60,15 @@ void ButtonCallbackTank (int button, int state)
 
 void setup()
 {
+  bool result;
+
   Serial.begin(115200);
   BLEDevice::init ("");
-  myLEGORemote.Init ();
+  do {
+    result = myLEGORemote.Init ();
+    if (!result)
+      delay(1000);
+  } while (!result);
   myCircuitCube1.Init ();
 #ifdef TRAIN_CONTROL
   myCircuitCube2.Init ();


### PR DESCRIPTION
Switching the CircuitCube on, i.e. in bluetooth mode, it permanently waits for pairing. In contrast to this, pressing the green button on the Lego PoweredUp remote control has a timeout and stops waiting for pairing if not paired after some seconds.

As the existing code here scans for the PoweredUp remote control only once at startup, this code and the remote control have to be started (powered & green button pressed) more or less at the same time. This makes handling slightly unconvenient and might result in a non-paired remote control.

Improve this by adding an infinite loop which waits for the remote control being paired successfully.