### PR TITLE
main: ButtonCallbackTank: Use stop switch for 3rd channel

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,10 +47,10 @@ void ButtonCallbackTank (int button, int state)
             vel[idx] = 0;
             break;
         case(LEGORemote::UP):
-            vel[idx] = 255;
+            vel[idx] = 200;
             break;
         case(LEGORemote::DOWN):
-            vel[idx] = -255;
+            vel[idx] = -200;
             break;
         case(LEGORemote::STOP):
             vel[idx] = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 
 int vel[2] = {0,0};
 int acc[2] = {0,0};
+int stop = 0;
 
 #ifdef TRAIN_CONTROL
 CircuitCube myCircuitCube1 ("FC:58:FA:86:E9:38");
@@ -53,7 +54,7 @@ void ButtonCallbackTank (int button, int state)
             vel[idx] = -200;
             break;
         case(LEGORemote::STOP):
-            vel[idx] = 0;
+            stop = (idx==0) ? 200 : 0;
             break;
     }
 }
@@ -86,7 +87,7 @@ void loop()
     myCircuitCube1.SetVelocities (vel[0], vel[0], vel[0]);
     myCircuitCube2.SetVelocities (vel[1], vel[1], vel[1]);
 #else
-    myCircuitCube1.SetVelocities (vel[0], 0, vel[1]);
+    myCircuitCube1.SetVelocities (vel[0], stop, vel[1]);
 #endif
     log_i ("v1: %d, a1: %d  -  v2: %d, a2: %d", vel[0], acc[0], vel[1], acc[1]);
 } // End of loop


### PR DESCRIPTION
Use the left and right stop button to control the 3rd channel of the
CircuitCube. As we are using the RELEASED event to set the channels
back to 0, we don't need the stop buttons for the same. So we can use
the stop buttons for other actions.

In this change the left stop button is used to enable the 3rd CircuitCube
output, while the right stop button disables it. This can be used, e.g.
to control a light attached to this channel.

This is for non TRAIN_CONTROL mode (i.e. TRAIN_CONTROL define disabled).